### PR TITLE
Ensure returned keys represent fully qualified file names.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # @nitric/snippy
 
+![Tests](https://github.com/nitrictech/snippy/actions/workflows/test.yaml/badge.svg?branch=main)
+[![codecov](https://codecov.io/gh/nitrictech/snippy/branch/main/graph/badge.svg?token=FFKZJQJQ3L)](https://codecov.io/gh/nitrictech/snippy)
+[![Version](https://img.shields.io/npm/v/@nitric/snippy.svg)](https://npmjs.org/package/@nitric/snippy)
+[![Downloads/week](https://img.shields.io/npm/dw/@nitric/snippy.svg)](https://npmjs.org/package/@nitric/snippy)
+
+
 > The Code snippet parser.
 
 The `@nitric/snippy` package was created to find and parse snippets into readable data that can be consumed by any application.
@@ -13,31 +19,6 @@ This package was used to create all code snippets used in the [nitric documentat
 - **Typed**. Has entensive TypeScript declarations.
 
 ## Usage
-
-### Node 12+
-
-Install with `npm install @nitric/snippy`, or `yarn add @nitric/snippy`
-
-```typescript
-import { snippy } from '@nitric/snippy';
-
-const result = await snippy({
-  repos: [
-    {
-      url: 'nitrictech/node-sdk',
-      exts: ['ts', 'js'],
-    },
-    {
-      url: 'nitrictech/go-sdk',
-      exts: ['go'],
-    },
-    {
-      url: 'nitrictech/python-sdk',
-      exts: ['py'],
-    },
-  ],
-}).parse();
-```
 
 ### Node 12+
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 export * from './snippy';
+
+export { findByFileName } from './utils';

--- a/src/snippy.test.ts
+++ b/src/snippy.test.ts
@@ -146,7 +146,7 @@ describe('Snippy Client Tests', () => {
       });
 
       await expect(snippyClient.parse()).resolves.toEqual({
-        'get-document.ts': {
+        'nitrictech/snippet-spike/get-document.ts': {
           name: 'get-document.ts',
           lang: 'typescript',
           content:

--- a/src/snippy.ts
+++ b/src/snippy.ts
@@ -160,7 +160,7 @@ export class Snippy {
                   file.html_url +
                   `#L${snippet.lineNumbers[0]}-L${lineNumbers[1]}`;
 
-                MANIFEST[file.name] = snippet;
+                MANIFEST[`${file.repository.full_name}/${file.path}`] = snippet;
               })
             )
           );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -41,13 +41,16 @@ describe('findByFileName', () => {
       lang: 'typescript',
       content: 'test',
       lineNumbers: [10, 11],
-      url: 'https://github.com/nitrictech/node-sdk/blob/f678b64f0c4b905ac6b3360f95ce0397d800bfe0/examples/documents/get.ts'
+      url: 'https://github.com/nitrictech/node-sdk/blob/f678b64f0c4b905ac6b3360f95ce0397d800bfe0/examples/documents/get.ts',
     };
 
-    const snippet = findByFileName({
-      'nitrictech/node-sdk/examples/documents/get.ts': exampleSnippet
-    }, 'get.ts');
+    const snippet = findByFileName(
+      {
+        'nitrictech/node-sdk/examples/documents/get.ts': exampleSnippet,
+      },
+      'get.ts'
+    );
 
-    expect(snippet).toEqual(exampleSnippet)
+    expect(snippet).toEqual(exampleSnippet);
   });
-})
+});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { minIndent, rawContentUrl } from './utils';
+import { findByFileName, minIndent, rawContentUrl } from './utils';
 
 describe('Test Utils', () => {
   test('Test that the minIndent method produces correct result', () => {
@@ -28,3 +28,26 @@ describe('Test Utils', () => {
     );
   });
 });
+
+describe('findByFileName', () => {
+  test('file with name does not exist', () => {
+    const snippet = findByFileName({}, 'fake.ts');
+    expect(snippet).toBeUndefined();
+  });
+
+  test('file with name exists', () => {
+    const exampleSnippet = {
+      name: 'get.ts',
+      lang: 'typescript',
+      content: 'test',
+      lineNumbers: [10, 11],
+      url: 'https://github.com/nitrictech/node-sdk/blob/f678b64f0c4b905ac6b3360f95ce0397d800bfe0/examples/documents/get.ts'
+    };
+
+    const snippet = findByFileName({
+      'nitrictech/node-sdk/examples/documents/get.ts': exampleSnippet
+    }, 'get.ts');
+
+    expect(snippet).toEqual(exampleSnippet)
+  });
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { SnippyResponse, SnippySnippet } from "./types";
+import { SnippyResponse, SnippySnippet } from './types';
 
 // limitations under the License.
 export const minIndent = (str: string) => {
@@ -27,6 +27,9 @@ export const minIndent = (str: string) => {
 export const rawContentUrl = (url: string) =>
   url.replace('github.com', 'raw.githubusercontent.com').replace('/blob', '');
 
-export const findByFileName = (response: SnippyResponse, fileName: string): SnippySnippet | undefined => {
-  return Object.values(response).find(s => s.name === fileName);
-}
+export const findByFileName = (
+  response: SnippyResponse,
+  fileName: string
+): SnippySnippet | undefined => {
+  return Object.values(response).find((s) => s.name === fileName);
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import { SnippyResponse, SnippySnippet } from "./types";
+
+// limitations under the License.
 export const minIndent = (str: string) => {
   const match = str.match(/^[ \t]*(?=\S)/gm);
 
@@ -23,3 +26,7 @@ export const minIndent = (str: string) => {
 
 export const rawContentUrl = (url: string) =>
   url.replace('github.com', 'raw.githubusercontent.com').replace('/blob', '');
+
+export const findByFileName = (response: SnippyResponse, fileName: string): SnippySnippet | undefined => {
+  return Object.values(response).find(s => s.name === fileName);
+}


### PR DESCRIPTION
To better support more nested example structures and not rely on unique file naming, keys that snippy returns should be fully qualified in order to avoid files being overwritten from name collisions.

Fully qualified name is: `<reponame>/<filepath>`; e.g. `nitrictech/node-sdk/examples/documents/get.ts`;

Existing find capability for snippets could be facilitated by searching for objects by their name or an endsWith on the returned keys, or with the already contained name property for simple file name searches.
```typescript
const results = await snippyclient.parse();

let snippet = results[snippetName];

if (!snippet) {
  const key = Object.entries(results).find(k => k.endsWith(snippetName))
  snippet = results[key];
  // handle not found case...
}
```